### PR TITLE
Add qla2xxx_wwn WWN type

### DIFF
--- a/rtslib/config.py
+++ b/rtslib/config.py
@@ -347,6 +347,9 @@ class Config(object):
         elif val_type == 'naa':
             if is_valid_wwn('naa', value):
                 valid_value = value
+        elif val_type == 'qla2xxx_wwn':
+            if is_valid_wwn('qla2xxx_wwn', value):
+                valid_value = value
         elif val_type == 'backend':
             if is_valid_backend(value, parent):
                 valid_value = value

--- a/rtslib/utils.py
+++ b/rtslib/utils.py
@@ -560,6 +560,10 @@ def is_valid_wwn(wwn_type, wwn, wwn_list=None):
             and re.match(
                 "[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}$", wwn):
         return True
+    elif wwn_type == 'qla2xxx_wwn' \
+            and re.match(
+                "[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){7}$", wwn):
+        return True
     else:
         return False
 


### PR DESCRIPTION
The qla2xxx_wwn type is used in policy/fabric_qla2xxx.lio but is not a
valid type in rtslib.config.Config.validate_val(). This commit adds
validation for this type in rtslib.config.Config.validate_val() and
rtslib.utils.is_valid_wwn().

This allows a system with existing targets (created by an older
targetcli/lio-utils) to be validated by rtslib and for the configuration
to be saved.

Signed-off-by: Chris Boot bootc@bootc.net
