### PR TITLE
target: fix broken TPG enable=0 handling

### DIFF
--- a/rtslib/target.py
+++ b/rtslib/target.py
@@ -999,11 +999,12 @@ class TPG(CFSNode):
         '''
         self._check_self()
         path = "%s/enable" % self.path
-        if os.path.isfile(path) and (boolean != self._get_enable()):
-            try:
-                fwrite(path, str(int(boolean)))
-            except IOError, e:
-                raise RTSLibError("Cannot change enable state: %s" % e)
+        if os.path.isfile(path):
+            if (boolean != self._get_enable()):
+                try:
+                    fwrite(path, str(int(boolean)))
+                except IOError, e:
+                    raise RTSLibError("Cannot change enable state: %s" % e)
         elif not boolean:
             raise RTSLibError("TPG cannot be disabled.")
 


### PR DESCRIPTION
A "TPG cannot be disabled" error is incorrectly thrown when attempting
to apply a configuration with a disabled TPG.

I think the intention of the code was to fail disable requests if the
$tpg/enable configfs path doesn't exist, and only write to the path if
it's current value doesn't match the requested setting... The logic was
just incorrect.

Signed-off-by: David Disseldorp ddiss@suse.de
