### PR TITLE
utils.py: Fix logic for determining word size

### DIFF
--- a/rtslib/utils.py
+++ b/rtslib/utils.py
@@ -19,6 +19,7 @@ under the License.
 
 import re
 import os
+import sys
 import stat
 import uuid
 import glob
@@ -619,7 +620,7 @@ def list_eth_names(max_eth=1024):
     struct.
     '''
     SIOCGIFCONF = 0x8912
-    if os.uname()[4].endswith("_64"):
+    if sys.maxsize > 2**32:
         offset = 40
     else:
         offset = 32


### PR DESCRIPTION
Currently function list_eth_names determines arch word size by checking for suffix '_64' in os.uname() arch string. This doesn't work on ppc64le platform as the architecture string is reported as 'ppc64le'. Hence the function when executed on ppc64le machine incorrectly assumes that its running on a 32-bit platform. This results in incorrect interface names being evaluated and finally results in error "ValueError: You must specify a valid interface name." during network portal creation.

This patch changes function list_eth_names to use sys.maxsize value to determine word size of the architecture and ultimately use an appropriate offset value in struct ifconf returned from ioctl call.